### PR TITLE
Fetch all releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM node
 
 COPY . .
 
+RUN yarn install
+
 ENTRYPOINT ["yarn", "run"]
 CMD ["start"]

--- a/lib/sentry-delete-old-releases.js
+++ b/lib/sentry-delete-old-releases.js
@@ -53,9 +53,9 @@ async function getReleaseFromServerPaginated(paginatedUrl) {
   }
 }
 
-async function getAllReleasesFromServer(releaseEndpoint) {
+async function getAllReleasesFromServer() {
   let morePagesAvailable = true
-  let paginatedUrl = releaseEndpoint
+  let paginatedUrl = `${SENTRY_BASE_URL}/api/0/organizations/${SENTRY_ORGANIZATION}/releases/`
   let allData = []
 
   while (morePagesAvailable) {
@@ -113,8 +113,7 @@ async function deleteReleasesOlderThanDays(dryRun) {
     throw new Error('Environment variables not set correctly.')
   }
 
-  const releaseEndpoint = `${SENTRY_BASE_URL}/api/0/organizations/${SENTRY_ORGANIZATION}/releases/`
-  const releases = await getAllReleasesFromServer(releaseEndpoint)
+  const releases = await getAllReleasesFromServer()
   console.log('found', releases.length, 'releases') // eslint-disable-line no-console
 
   const releaseVersionsToDelete = releases

--- a/lib/sentry-delete-old-releases.js
+++ b/lib/sentry-delete-old-releases.js
@@ -1,6 +1,3 @@
-const https = require('https')
-const http = require('http')
-const url = require('url')
 const parseLinkHeader = require('parse-link-header')
 const axios = require('axios')
 
@@ -14,16 +11,12 @@ const {
   SENTRY_PROJECT,
   SENTRY_DAYS_TO_KEEP,
 } = process.env
-const parsedUrl = SENTRY_BASE_URL ? url.parse(SENTRY_BASE_URL) : {}
-const SENTRY_HOST = parsedUrl.host
-const REQUEST = parsedUrl.protocol === 'https:' ? https : http
 
 function verifyEnvironmentVariables() {
   return !!SENTRY_BASE_URL
     && !!SENTRY_TOKEN
     && !!SENTRY_ORGANIZATION
     && !!SENTRY_PROJECT
-    && !!SENTRY_HOST
     && !!SENTRY_DAYS_TO_KEEP
 }
 
@@ -77,35 +70,18 @@ function getReleaseVersion(release) {
   return release.version
 }
 
-function deleteReleaseVersionFromServer(releaseVersion) {
-  const deleteOptions = {
-    host: SENTRY_HOST,
-    path: `/api/0/organizations/${SENTRY_ORGANIZATION}/releases/${releaseVersion}/`,
+async function deleteReleaseVersionFromServer(releaseVersion) {
+  const endpoint = `${SENTRY_BASE_URL}/api/0/organizations/${SENTRY_ORGANIZATION}/releases/${releaseVersion}/`
+
+  const options = {
     headers: {
       Authorization: `Bearer ${SENTRY_TOKEN}`,
     },
-    method: 'DELETE',
   }
 
-  return new Promise((resolve, reject) => {
-    REQUEST
-      .request(deleteOptions, (res) => {
-        const { statusCode } = res
-
-        if (statusCode !== 200) {
-          const error = new Error(`Request Failed. Status Code: ${statusCode}`)
-          console.error(error.message) // eslint-disable-line no-console
-          // consume response data to free up memory
-          res.resume()
-          reject(error)
-        }
-      })
-      .on('error', (e) => {
-        console.error(`Got error: ${e.message}`) // eslint-disable-line no-console
-        reject(e)
-      })
-    resolve()
-  })
+  console.log(`Deleting ${releaseVersion} ...`)
+  await axios.delete(endpoint, options)
+  console.log('Done.')
 }
 
 async function deleteReleasesOlderThanDays(dryRun) {
@@ -125,12 +101,25 @@ async function deleteReleasesOlderThanDays(dryRun) {
     console.log(`No releases older than ${SENTRY_DAYS_TO_KEEP} days for project "${SENTRY_PROJECT}" found.`) // eslint-disable-line no-console
     return
   }
-  console.log(`Found ${releaseVersionsToDelete.length} release versions to delete, specifically:`) // eslint-disable-line no-console
-  releaseVersionsToDelete.map(version => console.log(version)) // eslint-disable-line no-console
+  console.log(`Found ${releaseVersionsToDelete.length} release versions to delete.`) // eslint-disable-line no-console
 
   if (!dryRun) {
-    const statusCode = await deleteReleaseVersionFromServer(releaseVersionsToDelete)
-    console.log('Done. Statuscode: ', statusCode) // eslint-disable-line no-console
+    const errors = []
+    for (let i = 0; i < releaseVersionsToDelete.length; i += 1) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await deleteReleaseVersionFromServer(releaseVersionsToDelete[i])
+      } catch (error) {
+        console.log('Error.')
+        errors.push(error)
+      }
+    }
+    console.log('-----------------------------------------') // eslint-disable-line no-console
+    const deletedReleases = releaseVersionsToDelete.length - errors.length
+    console.log(`Deleted ${deletedReleases} releases. ${errors.length} releases were not deleted because the Sentry server rejected the request. Reasons:`)
+    errors.forEach((error) => {
+      console.log(`* ${error.response.data.detail}`)
+    })
   } else {
     console.log('-----------------------------------------') // eslint-disable-line no-console
     console.log('Nothing deleted since this was a dry run.') // eslint-disable-line no-console

--- a/lib/sentry-delete-old-releases.js
+++ b/lib/sentry-delete-old-releases.js
@@ -1,6 +1,8 @@
 const https = require('https')
 const http = require('http')
 const url = require('url')
+const parseLinkHeader = require('parse-link-header')
+const axios = require('axios')
 
 const { isReleaseOlderThanDays } = require('./is-release-older-than-days')
 const { isReleaseAssociatedWithProject } = require('./is-release-associated-with-project')
@@ -25,47 +27,49 @@ function verifyEnvironmentVariables() {
     && !!SENTRY_DAYS_TO_KEEP
 }
 
-function getAllReleasesFromServer() {
+async function getReleaseFromServerPaginated(paginatedUrl) {
   const options = {
-    host: SENTRY_HOST,
-    path: `/api/0/organizations/${SENTRY_ORGANIZATION}/releases/`,
     headers: {
       Authorization: `Bearer ${SENTRY_TOKEN}`,
     },
   }
+  const res = await axios.get(paginatedUrl, options)
+  const { data, status } = res
+  const contentType = res.headers['content-type']
 
-  return new Promise((resolve, reject) => {
-    REQUEST
-      .get(options, (res) => {
-        const { statusCode } = res
-        const contentType = res.headers['content-type']
+  if (status !== 200) {
+    throw new Error(`Request Failed. Status Code: ${status}`)
+  } else if (!/^application\/json/.test(contentType)) {
+    throw new Error('Invalid content-type.\n' +
+      `Expected application/json but received ${contentType}`)
+  }
 
-        let error
-        if (statusCode !== 200) {
-          error = new Error(`Request Failed. Status Code: ${statusCode}`)
-        } else if (!/^application\/json/.test(contentType)) {
-          error = new Error('Invalid content-type.\n' +
-            `Expected application/json but received ${contentType}`)
-        }
+  const linkHeader = parseLinkHeader(res.headers.link)
 
-        if (error) {
-          console.error(error.message) // eslint-disable-line no-console
-          // consume response data to free up memory
-          res.resume()
-          reject(error)
-        }
+  return {
+    linkHeader,
+    data,
+  }
+}
 
-        let response = ''
-        res.on('data', (data) => {
-          response += data
-        })
-        res.on('end', () => resolve(JSON.parse(response)))
-      })
-      .on('error', (e) => {
-        console.error(`Got error: ${e.message}`) // eslint-disable-line no-console
-        reject(e)
-      })
-  })
+async function getAllReleasesFromServer(releaseEndpoint) {
+  let morePagesAvailable = true
+  let paginatedUrl = releaseEndpoint
+  let allData = []
+
+  while (morePagesAvailable) {
+    // We have to fetch pages one by one
+    // eslint-disable-next-line no-await-in-loop
+    const { data, linkHeader } = await getReleaseFromServerPaginated(paginatedUrl)
+
+    allData = allData.concat(data)
+
+    // the parsedHeader contains strings only
+    morePagesAvailable = (linkHeader.next.results === 'true')
+    paginatedUrl = linkHeader.next.url
+  }
+
+  return allData
 }
 
 function getReleaseVersion(release) {
@@ -108,7 +112,9 @@ async function deleteReleasesOlderThanDays(dryRun) {
     throw new Error('Environment variables not set correctly.')
   }
 
-  const releases = await getAllReleasesFromServer()
+  const releaseEndpoint = `${SENTRY_BASE_URL}/api/0/organizations/${SENTRY_ORGANIZATION}/releases/`
+  const releases = await getAllReleasesFromServer(releaseEndpoint)
+
   const releaseVersionsToDelete = releases
     .filter(release => isReleaseAssociatedWithProject(SENTRY_PROJECT, release))
     .filter(release => isReleaseOlderThanDays(SENTRY_DAYS_TO_KEEP, release))

--- a/lib/sentry-delete-old-releases.js
+++ b/lib/sentry-delete-old-releases.js
@@ -33,6 +33,7 @@ async function getReleaseFromServerPaginated(paginatedUrl) {
       Authorization: `Bearer ${SENTRY_TOKEN}`,
     },
   }
+  console.log('fetching url', paginatedUrl)
   const res = await axios.get(paginatedUrl, options)
   const { data, status } = res
   const contentType = res.headers['content-type']
@@ -114,6 +115,7 @@ async function deleteReleasesOlderThanDays(dryRun) {
 
   const releaseEndpoint = `${SENTRY_BASE_URL}/api/0/organizations/${SENTRY_ORGANIZATION}/releases/`
   const releases = await getAllReleasesFromServer(releaseEndpoint)
+  console.log('found', releases.length, 'releases') // eslint-disable-line no-console
 
   const releaseVersionsToDelete = releases
     .filter(release => isReleaseAssociatedWithProject(SENTRY_PROJECT, release))
@@ -124,8 +126,7 @@ async function deleteReleasesOlderThanDays(dryRun) {
     console.log(`No releases older than ${SENTRY_DAYS_TO_KEEP} days for project "${SENTRY_PROJECT}" found.`) // eslint-disable-line no-console
     return
   }
-
-  console.log('Release versions to delete:') // eslint-disable-line no-console
+  console.log(`Found ${releaseVersionsToDelete.length} release versions to delete, specifically:`) // eslint-disable-line no-console
   releaseVersionsToDelete.map(version => console.log(version)) // eslint-disable-line no-console
 
   if (!dryRun) {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "eslint-plugin-import": "^2.13.0",
     "mocha": "^5.2.0",
     "sinon": "^6.1.4"
+  },
+  "dependencies": {
+    "axios": "^0.18.0",
+    "parse-link-header": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,14 @@ assertion-error@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -224,7 +232,7 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-debug@3.1.0, debug@^3.1.0:
+debug@3.1.0, debug@=3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -470,6 +478,13 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+follow-redirects@^1.3.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.6.1.tgz#514973c44b5757368bad8bddfe52f81f015c94cb"
+  integrity sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==
+  dependencies:
+    debug "=3.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -591,6 +606,11 @@ inquirer@^3.0.6:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -822,6 +842,13 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-link-header@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-1.0.1.tgz#bedfe0d2118aeb84be75e7b025419ec8a61140a7"
+  integrity sha1-vt/g0hGK64S+deewJUGeyKYRQKc=
+  dependencies:
+    xtend "~4.0.1"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -1169,6 +1196,11 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+xtend@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
The [Sentry API uses pagination](https://docs.sentry.io/api/pagination/) for their responses. Unfortunately, releases which are too old are not showing up in the response list because of that.

This PR solves the following:
* follow `Link` header to fetch all pages of the results
* [releases can't be deleted if they are referenced by an active issue](https://github.com/getsentry/sentry/issues/5701) so we are not stopping on failed requests but printing the result at the end
* use `async/await` syntax to ease development